### PR TITLE
sound: soc: fix issue of reading non-boolean property with boolean in…

### DIFF
--- a/sound/soc/tegra/tegra_asoc_machine.c
+++ b/sound/soc/tegra/tegra_asoc_machine.c
@@ -212,7 +212,7 @@ static int get_num_codec_confs(struct platform_device *pdev, int *num_confs)
 			if (of_node_cmp(codec->name, "codec"))
 				continue;
 
-			if (of_property_read_bool(codec, "prefix"))
+			if (of_property_present(codec, "prefix"))
 				conf_count++;
 		}
 
@@ -303,7 +303,7 @@ static int parse_dt_codec_confs(struct snd_soc_card *card)
 			if (of_node_cmp(codec->name, "codec"))
 				continue;
 
-			if (!of_property_read_bool(codec, "prefix"))
+			if (!of_property_present(codec, "prefix"))
 				continue;
 
 			err = of_parse_phandle_with_args(codec, DAI, CELL, 0,


### PR DESCRIPTION
This patch is similar with last commit because of missing replacing of_property_read_bool() with of_property_present() when reading 'prefix' property.
So, I think maybe we can combine it with last commit. But it is up to you.

thanks,
Limeng